### PR TITLE
Add User login, authenticate post actions, update forms

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,9 @@ gem 'jbuilder', '~> 2.7'
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 4.0'
 # Use Active Model has_secure_password
-# gem 'bcrypt', '~> 3.1.7'
+gem 'bcrypt', '~> 3.1.7'
+
+gem 'rack-cors'
 
 # Use Active Storage variant
 # gem 'image_processing', '~> 1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,6 +62,7 @@ GEM
       zeitwerk (~> 2.3)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
+    bcrypt (3.1.16)
     bindex (0.8.1)
     bootsnap (1.7.5)
       msgpack (~> 1.0)
@@ -111,6 +112,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.5.2)
     rack (2.2.3)
+    rack-cors (1.1.1)
+      rack (>= 2.0.0)
     rack-proxy (0.7.0)
       rack
     rack-test (1.1.0)
@@ -204,6 +207,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  bcrypt (~> 3.1.7)
   bootsnap (>= 1.4.2)
   byebug
   capybara (>= 2.15)
@@ -211,6 +215,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)
   puma (~> 4.1)
+  rack-cors
   rails (~> 6.1.3, >= 6.1.3.2)
   sass-rails (>= 6)
   selenium-webdriver

--- a/app/controllers/api/v1/posts_controller.rb
+++ b/app/controllers/api/v1/posts_controller.rb
@@ -1,4 +1,6 @@
 class Api::V1::PostsController < ApplicationController
+  before_action :check_logged_in!, except: [:index, :show]
+
   def index
     posts = Post.where(published: true).order(created_at: :desc)
     render json: posts

--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -1,0 +1,43 @@
+class Api::V1::SessionsController < ApplicationController
+  def create
+    @user = User.find_by(username: session_params[:username])
+  
+    if @user && @user.authenticate(session_params[:password])
+      login!
+      render json: {
+        logged_in: true,
+        user: @user
+      }
+    else
+      render json: { 
+        errors: ['no such user, please try again']
+      }, status: 401
+    end
+  end
+
+  def is_logged_in?
+    if logged_in? && current_user
+      render json: {
+        logged_in: true,
+        user: current_user
+      }
+    else
+      render json: {
+        logged_in: false,
+        message: 'no such user'
+      }
+    end
+  end
+
+  def destroy
+    logout!
+    render json: {
+      logged_out: true
+    }, status: 200
+  end
+
+  private
+  def session_params
+    params.permit(:username, :password)
+  end
+end

--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -25,7 +25,7 @@ class Api::V1::SessionsController < ApplicationController
       render json: {
         logged_in: false,
         message: 'no such user'
-      }
+      }, status: 401
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,30 @@
 class ApplicationController < ActionController::Base
+  skip_before_action :verify_authenticity_token
+
+  helper_method :login!, :logged_in?, :current_user, :authorized_user?, :logout!, :set_user
+
+  def login!
+    session[:user_id] = @user.id
+  end
+
+  def logged_in?
+    !!session[:user_id]
+  end
+
+  def current_user
+    @current_user ||= User.find(session[:user_id]) if session[:user_id]
+  end
+
+  def authorized_user?
+    @user == current_user
+  end
+
+  def logout!
+    session.clear
+  end
+
+  def set_user
+    @user = User.find_by(id: session[:user_id])
+  end
+
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::Base
   skip_before_action :verify_authenticity_token
 
-  helper_method :login!, :logged_in?, :current_user, :authorized_user?, :logout!, :set_user
+  helper_method :login!, :logged_in?, :current_user, :authorized_user?, :logout!, :set_user, :check_logged_in!
 
   def login!
     session[:user_id] = @user.id
@@ -9,6 +9,15 @@ class ApplicationController < ActionController::Base
 
   def logged_in?
     !!session[:user_id]
+  end
+
+  def check_logged_in!
+    return true if logged_in?
+    render json: {
+      logged_in: false,
+      message: 'not logged in'
+    }, status: 401
+    return false
   end
 
   def current_user

--- a/app/javascript/components/ListDraftPosts.js
+++ b/app/javascript/components/ListDraftPosts.js
@@ -19,6 +19,12 @@ class ListDraftPosts extends React.Component {
         if (response.ok) {
           return response.json();
         }
+        else if (response.status === 401) {
+          this.props.history.push({
+            pathname: `/login`,
+            //state: {goal_uri: '/posts/drafts', message: ''},
+          })
+        }
         throw new Error('Network response was not ok.');
       })
       .then(response => this.setState({ posts: response }))

--- a/app/javascript/components/Login.js
+++ b/app/javascript/components/Login.js
@@ -1,0 +1,78 @@
+import React, { useState } from 'react'
+
+const ConfirmationMessage = ({user}) => (
+  <div className="alert alert-success">
+    <h1>Success</h1>
+    <p>You're logged in as user <em>{user.username}</em></p>
+  </div>
+)
+
+export default function Login() {
+  const [user, setLoggedIn] = useState(null)
+  const [errorMsg, setError] = useState(null)
+
+  const handleSubmit = (event) => {
+    event.preventDefault()
+    const form = event.target
+    const username = form.username.value
+    const password = form.password.value
+    fetch(`/api/v1/login`, {
+      method: 'post',
+      credentials: 'include',
+      body: JSON.stringify({ username, password }),
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    })
+    .then(response => {
+      if (response.ok) return response.json()
+      throw response.json()
+    })
+    .then(data => {
+      setLoggedIn(data.user)
+    })
+    .catch(errors => {
+      console.log('error', errors)
+      setError("Login was unsuccessful")
+    })
+
+  }
+
+  return (
+    <section className="container">
+      <div className="row">
+        <div className="col-xs-12 col-md-8 col-lg-6 mx-auto py-5">
+          {user ? <ConfirmationMessage user={user} /> : (
+            <>
+              <h2>Please log in</h2>
+              <form role="form" onSubmit={handleSubmit}>
+                <div className="form-group">
+                  <label htmlFor="username">Username</label>
+                  <input id="username" name="username" tabIndex="1" type="slug"
+                    className="form-control" placeholder="username" required />
+                </div>
+                <div className="form-group">
+                  <label htmlFor="password">Password</label>
+                  <input id="password" name="password" tabIndex="2" type="password"
+                    className="form-control" placeholder="************" required />
+                </div>
+                <div className="clearfix">
+                  <button tabIndex="3" className="btn btn-primary btn-lg" type="submit">
+                    Log in
+                  </button>
+                </div>
+                {errorMsg &&
+                  <div className="form-group py-4">
+                    <p className="text-danger">
+                      {errorMsg}
+                    </p>
+                  </div>
+                }
+              </form>
+            </>
+          )}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/app/javascript/components/NewPost.js
+++ b/app/javascript/components/NewPost.js
@@ -1,9 +1,9 @@
-import React from 'react';
-import { Link } from 'react-router-dom';
+import React from 'react'
+import { Link } from 'react-router-dom'
 
 class NewPost extends React.Component {
   constructor(props) {
-    super(props);
+    super(props)
     this.state = {
       title: '',
       name: '',
@@ -11,31 +11,31 @@ class NewPost extends React.Component {
       content: '',
       excerpt: '',
       image: '',
-    };
+    }
 
-    this.onChange = this.onChange.bind(this);
-    this.onSubmit = this.onSubmit.bind(this);
-    this.stripHtmlEntities = this.stripHtmlEntities.bind(this);
+    this.onChange = this.onChange.bind(this)
+    this.onSubmit = this.onSubmit.bind(this)
+    this.stripHtmlEntities = this.stripHtmlEntities.bind(this)
   }
 
   stripHtmlEntities(str) {
     return String(str)
       .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;');
+      .replace(/>/g, '&gt;')
   }
 
   onChange(event) {
-    this.setState({ [event.target.name]: event.target.value });
+    this.setState({ [event.target.name]: event.target.value })
   }
 
   onSubmit(event) {
-    event.preventDefault();
-    const url = '/api/v1/posts/create';
-    const { title, name, created_at, content, excerpt, image } = this.state;
+    event.preventDefault()
+    const url = '/api/v1/posts/create'
+    const { title, name, created_at, content, excerpt, image } = this.state
 
     // name must be present, and one of title, content or image must be present
     if (name.length == 0 || title.length == 0 && content.length == 0 && image.length == 0)
-      return;
+      return
 
     const body = {
       title,
@@ -44,9 +44,9 @@ class NewPost extends React.Component {
       content,
       excerpt,
       image
-    };
+    }
 
-    const token = document.querySelector('meta[name="csrf-token"]').content;
+    const token = document.querySelector('meta[name="csrf-token"]').content
     fetch(url, {
       method: 'POST',
       headers: {
@@ -57,18 +57,18 @@ class NewPost extends React.Component {
     })
       .then(response => {
         if (response.ok) {
-          return response.json();
+          return response.json()
         }
         else if (response.status === 401) {
           alert(`You must log in to perform this action. You can open the login page in another tab to keep your work here.`)
           throw new Error('Not authorized. Please log in.')
         }
-        throw new Error('Network response was not ok.');
+        throw new Error('Network response was not ok.')
       })
       .then(response => {
         if (response?.id) this.props.history.push(`/posts/${response.id}/update`)
       })
-      .catch(error => console.log(error.message));
+      .catch(error => console.log(error.message))
   }
 
   render() {
@@ -157,8 +157,8 @@ class NewPost extends React.Component {
           </div>
         </div>
       </div>
-    );
+    )
   }
 }
 
-export default NewPost;
+export default NewPost

--- a/app/javascript/components/NewPost.js
+++ b/app/javascript/components/NewPost.js
@@ -10,7 +10,7 @@ class NewPost extends React.Component {
       created_at: new Date().toISOString().substr(0, 10),
       content: '',
       excerpt: '',
-      image: ''
+      image: '',
     };
 
     this.onChange = this.onChange.bind(this);
@@ -59,9 +59,15 @@ class NewPost extends React.Component {
         if (response.ok) {
           return response.json();
         }
+        else if (response.status === 401) {
+          alert(`You must log in to perform this action. You can open the login page in another tab to keep your work here.`)
+          throw new Error('Not authorized. Please log in.')
+        }
         throw new Error('Network response was not ok.');
       })
-      .then(response => this.props.history.push(`/posts/${response.id}`))
+      .then(response => {
+        if (response?.id) this.props.history.push(`/posts/${response.id}/update`)
+      })
       .catch(error => console.log(error.message));
   }
 

--- a/app/javascript/components/Post.js
+++ b/app/javascript/components/Post.js
@@ -60,6 +60,10 @@ class Post extends React.Component {
         if (response.ok) {
           return response.json();
         }
+        else if (response.status === 401) {
+          alert(`You must log in to perform this action.`)
+          throw new Error('Not authorized. Please log in.');
+        }
         throw new Error("Network response was not ok.");
       })
       .then(() => this.props.history.push("/posts"))

--- a/app/javascript/components/Post.js
+++ b/app/javascript/components/Post.js
@@ -1,53 +1,53 @@
-import React from 'react';
-import { Link } from 'react-router-dom';
-import PostBody from './PostBody';
-import face from '../../assets/images/profile-picture.jpg';
+import React from 'react'
+import { Link } from 'react-router-dom'
+import PostBody from './PostBody'
+import face from '../../assets/images/profile-picture.jpg'
 
 class Post extends React.Component {
   constructor(props) {
-    super(props);
+    super(props)
 
     const {
       match: {
         params: { id }
       }
-    } = this.props;
+    } = this.props
 
     this.state = {
       post: {
         id,
         name: ''
       }
-    };
+    }
 
-    this.addHtmlEntities = this.addHtmlEntities.bind(this);
-    this.deletePost = this.deletePost.bind(this);
+    this.addHtmlEntities = this.addHtmlEntities.bind(this)
+    this.deletePost = this.deletePost.bind(this)
   }
 
   componentDidMount() {
-    const url = `/api/v1/posts/show/${this.state.post.id}`;
+    const url = `/api/v1/posts/show/${this.state.post.id}`
     fetch(url)
       .then(response => {
         if (response.ok) {
-          return response.json();
+          return response.json()
         }
-        throw new Error('Network response was not ok.');
+        throw new Error('Network response was not ok.')
       })
       .then(response => this.setState({ post: response }))
-      .catch(() => this.props.history.push('/posts'));
+      .catch(() => this.props.history.push('/posts'))
   }
 
   addHtmlEntities(str) {
     return String(str)
       .replace(/&lt;/g, '<')
-      .replace(/&gt;/g, '>');
+      .replace(/&gt;/g, '>')
   }
 
   deletePost() {
-    if (!confirm('Are you sure you want to delete this post?')) return;
+    if (!confirm('Are you sure you want to delete this post?')) return
 
-    const url = `/api/v1/posts/destroy/${this.state.post.id}`;
-    const token = document.querySelector('meta[name="csrf-token"]').content;
+    const url = `/api/v1/posts/destroy/${this.state.post.id}`
+    const token = document.querySelector('meta[name="csrf-token"]').content
 
     fetch(url, {
       method: "DELETE",
@@ -58,21 +58,21 @@ class Post extends React.Component {
     })
       .then(response => {
         if (response.ok) {
-          return response.json();
+          return response.json()
         }
         else if (response.status === 401) {
           alert(`You must log in to perform this action.`)
-          throw new Error('Not authorized. Please log in.');
+          throw new Error('Not authorized. Please log in.')
         }
-        throw new Error("Network response was not ok.");
+        throw new Error("Network response was not ok.")
       })
       .then(() => this.props.history.push("/posts"))
-      .catch(error => console.log(error.message));
+      .catch(error => console.log(error.message))
   }
 
   render() {
-    const { post } = this.state;
-    const user = false;
+    const { post } = this.state
+    const user = false
     return (
       <div className="container-fluid px-0">
         <PostBody {...post}>
@@ -93,8 +93,8 @@ class Post extends React.Component {
           </>
         </PostBody>
       </div>
-    );
+    )
   }
 }
 
-export default Post;
+export default Post

--- a/app/javascript/components/UpdatePost.js
+++ b/app/javascript/components/UpdatePost.js
@@ -191,7 +191,7 @@ class UpdatePost extends React.Component {
                 />
               </div>
               <div className="form-group">
-                <label className="form-check-label" for="publishedCheck">Publish&nbsp;</label>
+                <label className="form-check-label" htmlFor="publishedCheck">Publish&nbsp;</label>
                 <input
                   type="checkbox"
                   name="published"

--- a/app/javascript/components/UpdatePost.js
+++ b/app/javascript/components/UpdatePost.js
@@ -98,6 +98,10 @@ class UpdatePost extends React.Component {
         if (response.ok) {
           return response.json();
         }
+        else if (response.status === 401) {
+          alert(`You must log in to perform this action. You can open the login page in another tab to keep your work here.`);
+          throw new Error('Not authorized. Please log in.');
+        }
         throw new Error('Network response was not ok.');
       })
       .then(() => console.log('updated the post'))

--- a/app/javascript/components/UpdatePost.js
+++ b/app/javascript/components/UpdatePost.js
@@ -1,16 +1,16 @@
-import React from 'react';
-import { Link } from 'react-router-dom';
-import PostBody from './PostBody';
+import React from 'react'
+import { Link } from 'react-router-dom'
+import PostBody from './PostBody'
 
 class UpdatePost extends React.Component {
   constructor(props) {
-    super(props);
+    super(props)
 
     const {
       match: {
         params: { id }
       }
-    } = this.props;
+    } = this.props
 
     this.state = {
       post: {
@@ -23,57 +23,57 @@ class UpdatePost extends React.Component {
         image: '',
         published: false,
       },
-      changed: false
-    };
+      changed: false,
+    }
 
-    this.onChange = this.onChange.bind(this);
-    this.onSubmit = this.onSubmit.bind(this);
-    this.addHtmlEntities = this.addHtmlEntities.bind(this);
-    this.stripHtmlEntities = this.stripHtmlEntities.bind(this);
+    this.onChange = this.onChange.bind(this)
+    this.onSubmit = this.onSubmit.bind(this)
+    this.addHtmlEntities = this.addHtmlEntities.bind(this)
+    this.stripHtmlEntities = this.stripHtmlEntities.bind(this)
   }
 
   componentDidMount() {
-    const url = `/api/v1/posts/show/${this.state.post.id}`;
+    const url = `/api/v1/posts/show/${this.state.post.id}`
 
     fetch(url)
       .then(response => {
         if (response.ok) {
-          return response.json();
+          return response.json()
         }
-        throw new Error('Network response was not ok.');
+        throw new Error('Network response was not ok.')
       })
       .then(response => {
-        response.created_at = new Date(response.created_at).toISOString().substr(0, 10);
-        return response;
+        response.created_at = new Date(response.created_at).toISOString().substr(0, 10)
+        return response
       })
       .then(response => this.setState({ post: response }))
-      .catch(() => this.props.history.push('/posts'));
+      .catch(() => this.props.history.push('/posts'))
   }
 
   stripHtmlEntities(str) {
     return String(str)
       .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;');
+      .replace(/>/g, '&gt;')
   }
 
   addHtmlEntities(str) {
     return String(str)
       .replace(/&lt;/g, '<')
-      .replace(/&gt;/g, '>');
+      .replace(/&gt;/g, '>')
   }
 
   onChange(event) {
     const val = event.target.type === 'checkbox'
       ? event.target.checked
       : event.target.value
-    const post = { ...this.state.post, [event.target.name]: val };
-    this.setState({ post });
-    this.setState({ changed: true });
+    const post = { ...this.state.post, [event.target.name]: val }
+    this.setState({ post })
+    this.setState({ changed: true })
   }
 
   onSubmit(event) {
-    event.preventDefault();
-    const url = `/api/v1/posts/update/${this.state.post.id}`;
+    event.preventDefault()
+    const url = `/api/v1/posts/update/${this.state.post.id}`
 
     const body = {
       title: this.state.post.title,
@@ -85,7 +85,7 @@ class UpdatePost extends React.Component {
       published: this.state.post.published,
     }
 
-    const token = document.querySelector('meta[name="csrf-token"]').content;
+    const token = document.querySelector('meta[name="csrf-token"]').content
     fetch(url, {
       method: 'POST',
       headers: {
@@ -96,17 +96,17 @@ class UpdatePost extends React.Component {
     })
       .then(response => {
         if (response.ok) {
-          return response.json();
+          return response.json()
         }
         else if (response.status === 401) {
-          alert(`You must log in to perform this action. You can open the login page in another tab to keep your work here.`);
-          throw new Error('Not authorized. Please log in.');
+          alert(`You must log in to perform this action. You can open the login page in another tab to keep your work here.`)
+          throw new Error('Not authorized. Please log in.')
         }
-        throw new Error('Network response was not ok.');
+        throw new Error('Network response was not ok.')
       })
       .then(() => console.log('updated the post'))
       .then(() => this.setState({ changed: false }))
-      .catch(error => console.log(error.message));
+      .catch(error => console.log(error.message))
   }
 
   render() {
@@ -214,8 +214,8 @@ class UpdatePost extends React.Component {
           </div>
         </div>
       </div>
-    );
+    )
   }
 }
 
-export default UpdatePost;
+export default UpdatePost

--- a/app/javascript/routes/Index.js
+++ b/app/javascript/routes/Index.js
@@ -6,6 +6,7 @@ import Post from '../components/Post';
 import NewPost from '../components/NewPost';
 import UpdatePost from '../components/UpdatePost';
 import Brand from '../components/Brand';
+import Login from '../components/Login';
 
 export default (
   <Router>
@@ -13,6 +14,7 @@ export default (
       <Route path='/' exact component={Posts} />
       <Route path='/brand' exact component={Brand} />
       <Route path='/posts' exact component={Posts} />
+      <Route path='/login' exact component={Login} />
       <Route path='/posts/drafts' exact component={ListDraftPosts} />
       <Route path='/posts/new' exact component={NewPost} />
       <Route path='/posts/:id(\d+)' exact component={Post} />

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,6 @@
+class User < ApplicationRecord
+  has_secure_password
+  validates :username, presence: true
+  validates :username, uniqueness: true
+  validates :username, length: { minimum: 4 }
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,9 @@ module MichaelsnookCom
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
 
+    config.middleware.use ActionDispatch::Cookies
+    config.middleware.use ActionDispatch::Session::CookieStore
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/initializers/cookies_serializer.rb
+++ b/config/initializers/cookies_serializer.rb
@@ -2,4 +2,4 @@
 
 # Specify a serializer for the signed and encrypted cookie jars.
 # Valid options are :json, :marshal, and :hybrid.
-Rails.application.config.action_dispatch.cookies_serializer = :json
+Rails.application.config.action_dispatch.cookies_serializer = :hybrid

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,0 +1,9 @@
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins 'localhost:3001'
+    resource '*',
+      headers: :any,
+      methods: [:get, :post, :patch, :put, :delete, :options, :head],
+      credentials: true
+  end
+end

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,0 +1,5 @@
+if Rails.env === 'production'
+  Rails.application.config.session_store :cookie_store, key: '_michaelsnook-dot-com', domain: 'michaelsnook.com'
+else
+  Rails.application.config.session_store :cookie_store, key: '_michaelsnook-dot-com'
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,10 @@ Rails.application.routes.draw do
       get    'posts/show/:id',    to: 'posts#show'
       post   'posts/update/:id',  to: 'posts#update'
       delete 'posts/destroy/:id', to: 'posts#destroy'
+
+      post   '/login',            to: 'sessions#create'
+      post   '/logout',           to: 'sessions#destroy'
+      get    '/logged_in',        to: 'sessions#is_logged_in?'
     end
   end
 

--- a/db/migrate/20210714182735_create_users.rb
+++ b/db/migrate/20210714182735_create_users.rb
@@ -1,0 +1,11 @@
+class CreateUsers < ActiveRecord::Migration[6.1]
+  def change
+    create_table :users do |t|
+      t.string :username
+      t.string :email
+      t.string :password_digest
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_09_014300) do
+ActiveRecord::Schema.define(version: 2021_07_14_182735) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -24,6 +24,14 @@ ActiveRecord::Schema.define(version: 2021_07_09_014300) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "published", default: false, null: false
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "username"
+    t.string "email"
+    t.string "password_digest"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
 end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  username: MyString
+  email: MyString
+  password_digest: MyString
+
+two:
+  username: MyString
+  email: MyString
+  password_digest: MyString

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class UserTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Based [on this article](https://medium.com/swlh/react-reactions-cfdde7f08dff).

_Note: this PR is the first using a new style approach: hooks for statee instead of classes, and no semicolons._

This PR makes all the Rails changes to the rails controllers/routes to add sessions, cookies, cors control, user model, password, bcrypt, and several helpers like `login!` and `logged_in?`. On the React side it handles most of these changes, using `credentials: true` on fetches where required, adding a login form page, and ensuring fetch's handlers properly deal with errors and catch bad responses (especially 401s).

Left to be done in future work: testing these changes with the "delete" button, creating a general "is logged in" context state so we don't even show forms that can't be used yet, so we can conditionally add back the Edit and Delete buttons that I removed recently, and making the Login form into a modal that can be presented any time a request returns with a 401, without having to redirect and come back.